### PR TITLE
everyday rspec/05 controllers

### DIFF
--- a/everyday-rspec/spec/controllers/home_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe HomeController, type: :controller do
+  describe '#index' do
+    # 正常にレスポンスを返すこと
+    it "responds successfully" do
+      get :index
+
+      # response はブラウザに返すべきアプリケーションの全データを保持しているオブジェクト
+      expect(response).to be_successful
+    end
+
+    # 200レスポンスを返すこと
+    it "responds a 200 response" do
+      get :index
+
+      # response はブラウザに返すべきアプリケーションの全データを保持しているオブジェクト
+      expect(response).to have_http_status "200"
+    end
+  end
+
+end

--- a/everyday-rspec/spec/controllers/home_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/home_controller_spec.rb
@@ -18,5 +18,4 @@ RSpec.describe HomeController, type: :controller do
       expect(response).to have_http_status "200"
     end
   end
-
 end

--- a/everyday-rspec/spec/controllers/projects_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/projects_controller_spec.rb
@@ -73,4 +73,178 @@ RSpec.describe ProjectsController, type: :controller do
       end
     end
   end
+
+  describe '#create' do
+    # 認証済みのユーザーとして
+    context "as an authenticated user" do
+      before do
+        @user = FactoryBot.create(:user)
+      end
+
+      # プロジェクトを追加できること
+      it 'adds a project' do
+        project_params = FactoryBot.attributes_for(:project)
+        sign_in(@user)
+
+        expect{
+          post :create, params: { project: project_params}
+        }.to change(@user.projects, :count).by(1)
+      end
+    end
+
+    # ゲストとして
+    context 'as a guest' do
+      # 302レスポンスを返すこと
+      it 'returns 302 response' do
+        project_params = FactoryBot.attributes_for(:project)
+        post :create, params: { project: project_params }
+        expect(response).to have_http_status '302'
+      end
+
+      # サインイン画面にリダイレクトすること
+      it "redirect to the sign_in page" do
+        project_params = FactoryBot.attributes_for(:project)
+        post :create, params: { project: project_params }
+
+        expect(response).to redirect_to '/users/sign_in'
+      end
+    end
+  end
+
+  describe '#update' do
+    # 認可されたユーザーとして
+    context "as an authorized user" do
+      before do
+        @user = FactoryBot.create(:user)
+        @project = FactoryBot.create(:project, owner: @user)
+      end
+
+      # プロジェクトを更新できること
+      it 'updates a projcet' do
+        project_params = FactoryBot.attributes_for(:project, name: "New Project Name")
+        sign_in(@user)
+
+        patch :update, params: { id: @project.id, project: project_params }
+        expect(@project.reload.name).to eq "New Project Name"
+      end
+    end
+
+    # 認可されてないユーザーとして
+    context 'as an unahthorized user' do
+      before do
+        @user = FactoryBot.create(:user)
+        other_user = FactoryBot.create(:user)
+        @project = FactoryBot.create(:project, owner: other_user, name: 'Same Old Name')
+      end
+
+      # プロジェクトを更新できないこと
+      it 'does not update the project' do
+        project_params = FactoryBot.attributes_for(:project, name: "New name")
+        sign_in(@user)
+
+        patch :update, params: { id: @project.id, project: project_params }
+        expect(@project.reload.name).to eq 'Same Old Name'
+      end
+
+      # ダッシュボードへリダイレクトすること
+      it 'redirect to the dashboard' do
+        project_params = FactoryBot.attributes_for(:project, name: "New name")
+        sign_in(@user)
+
+        patch :update, params: { id: @project.id, project: project_params }
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    # ゲストユーザーとして
+    context 'as a guest' do
+      before do
+        @project = FactoryBot.create(:project)
+      end
+
+      # 302レスポンスを返すこと
+      it 'returns a 302 response' do
+        project_params = FactoryBot.attributes_for(:project)
+        patch :update, params: { id: @project.id, project: project_params }
+
+        expect(response).to have_http_status '302'
+      end
+
+      # サインイン画面にリダイレクトされること
+      it 'redirect to sign-in page' do
+        project_params = FactoryBot.attributes_for(:project)
+        patch :update, params: { id: @project.id, project: project_params }
+
+        expect(response).to redirect_to '/users/sign_in'
+      end
+
+    end
+  end
+
+  describe '#destroy' do
+    # 認可されたユーザーとして
+    context 'as an authenticated user' do
+      before do
+        @user = FactoryBot.create(:user)
+        @project = FactoryBot.create(:project, owner: @user)
+      end
+
+      # プロジェクトを削除できること
+      it 'delete a project' do
+        sign_in(@user)
+        expect{
+          delete :destroy, params: { id: @project.id }
+        }.to change(@user.projects, :count).by(-1)
+      end
+    end
+    # 認可されていないユーザーとして
+    context 'as unauthorized user' do
+      before do
+        @user = FactoryBot.create(:user)
+        other_user = FactoryBot.create(:user)
+        @project = FactoryBot.create(:project, owner: other_user)
+      end
+
+      # プロジェクトを削除できないこと
+      it 'does not delete the project' do
+        sign_in(@user)
+        expect{
+          delete :destroy, params: { id: @project.id }
+        }.to_not change(Project, :count)
+      end
+
+      # ダッシュボードにリダイレクトすること
+      it 'redirect to the dashboard' do
+        sign_in(@user)
+        delete :destroy, params: { id: @project.id }
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    # ゲストユーザーとして
+    context 'as a guest' do
+      before do
+        @project = FactoryBot.create(:project)
+      end
+
+      # 302レスポンスを返すこと
+      it 'returns a 302 response' do
+        delete :destroy, params: { id: @project.id }
+        expect(response).to have_http_status '302'
+      end
+
+      # サインイン画面にリダイレクトすること
+      it 'redirects to the sign-in page' do
+        delete :destroy, params: { id: @project.id }
+        expect(response).to redirect_to '/users/sign_in'
+      end
+
+      # プロジェクトを削除できないこと
+      it 'does not delete the project' do
+        expect{
+          delete :destroy, params: { id: @project.id }
+        }.to_not change(Project, :count)
+      end
+    end
+  end
 end

--- a/everyday-rspec/spec/controllers/projects_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/projects_controller_spec.rb
@@ -2,22 +2,75 @@ require 'rails_helper'
 
 RSpec.describe ProjectsController, type: :controller do
   describe '#index' do
-    before do
-      @user = FactoryBot.create(:user)
+    # 認証済みのユーザーとして
+    context 'as an authenticated user' do
+      before do
+        @user = FactoryBot.create(:user)
+      end
+
+      # 正常にレスポンスを返すこと
+      it "responds successfully" do
+        sign_in(@user)
+        get :index
+        expect(response).to be_successful
+      end
+
+      # 200レスポンスを返すこと
+      it "responds a 200 response" do
+        sign_in(@user)
+        get :index
+        expect(response).to have_http_status "200"
+      end
     end
 
-    # 正常にレスポンスを返すこと
-    it "responds successfully" do
-      sign_in(@user)
-      get :index
-      expect(response).to be_successful
+    # ゲストとして
+    context 'as a guest' do
+      # 302レスポンスを返すこと
+      it 'returns a 302 response' do
+        get :index
+        expect(response).to have_http_status "302"
+      end
+
+      # サインイン画面にリダイレクトすること
+      it 'redirects to sing-in page' do
+        get :index
+        expect(response).to redirect_to "/users/sign_in"
+      end
+    end
+  end
+
+  describe '#show' do
+    # 認可されたユーザーとして
+    context "as an authenticated user" do
+      before do
+        @user = FactoryBot.create(:user)
+        @project = FactoryBot.create(:project, owner: @user)
+      end
+
+      # 正常にレスポンスを返すこと
+      it "responds successfully" do
+        sign_in(@user)
+        get :show, params: { id: @project.id }
+
+        expect(response).to be_successful
+      end
     end
 
-    # 200レスポンスを返すこと
-    it "responds a 200 response" do
-      sign_in(@user)
-      get :index
-      expect(response).to have_http_status "200"
+    # 認可されていないユーザーとして
+    context "as an unauthorized user" do
+      before do
+        @user = FactoryBot.create(:user)
+        other_user = FactoryBot.create(:user)
+        @project = FactoryBot.create(:project, owner: other_user)
+      end
+
+      # ダッシュボードにリダイレクトすること
+      it "redirect to the dashboard" do
+        sign_in(@user)
+        get :show, params: { id: @project.id }
+
+        expect(response).to redirect_to root_path
+      end
     end
   end
 end

--- a/everyday-rspec/spec/controllers/projects_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/projects_controller_spec.rb
@@ -81,14 +81,30 @@ RSpec.describe ProjectsController, type: :controller do
         @user = FactoryBot.create(:user)
       end
 
-      # プロジェクトを追加できること
-      it 'adds a project' do
-        project_params = FactoryBot.attributes_for(:project)
-        sign_in(@user)
+      # 有効な属性の場合
+      context 'with valid attributes' do
+        # プロジェクトを追加できること
+        it 'adds a project' do
+          project_params = FactoryBot.attributes_for(:project)
+          sign_in(@user)
 
-        expect{
-          post :create, params: { project: project_params}
-        }.to change(@user.projects, :count).by(1)
+          expect{
+            post :create, params: { project: project_params}
+          }.to change(@user.projects, :count).by(1)
+        end
+      end
+
+      # 無効な属性の場合
+      context 'with invalid attributes' do
+        # プロジェクトを追加できないこと
+        it 'does not add a project' do
+          project_params = FactoryBot.attributes_for(:project, :invalid)
+          sign_in(@user)
+
+          expect {
+            post :create, params: { project: project_params }
+          }.to_not change(@user.projects, :count)
+        end
       end
     end
 

--- a/everyday-rspec/spec/controllers/projects_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ProjectsController, type: :controller do
+  describe '#index' do
+    before do
+      @user = FactoryBot.create(:user)
+    end
+
+    # 正常にレスポンスを返すこと
+    it "responds successfully" do
+      sign_in(@user)
+      get :index
+      expect(response).to be_successful
+    end
+
+    # 200レスポンスを返すこと
+    it "responds a 200 response" do
+      sign_in(@user)
+      get :index
+      expect(response).to have_http_status "200"
+    end
+  end
+end

--- a/everyday-rspec/spec/controllers/tasks_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/tasks_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe TasksController, type: :controller do
+  before do
+    @user = FactoryBot.create(:user)
+    @project = FactoryBot.create(:project, owner: @user)
+    @task = @project.tasks.create!(name: "Test task")
+  end
+
+  describe '#show' do
+    # JSON形式でレスポンスを返すこと
+    it 'responds with JSON formatted output' do
+      sign_in(@user)
+      get :show, format: :json, params: { project_id: @project.id, id: @task.id }
+      expect(response.content_type).to include('application/json')
+    end
+  end
+
+  describe '#create' do
+    # JSON形式でレスポンスを返すこと
+    it 'responds with JSON formatted output' do
+      new_task = { name: 'New test task' }
+      sign_in(@user)
+      post :create, format: :json, params: { project_id: @project.id, task: new_task }
+      expect(response.content_type).to include('application/json')
+    end
+
+    # 新しいタスクをプロジェクトに追加すること
+    it 'adds a new task to the project' do
+      new_task = { name: 'New test task' }
+      sign_in(@user)
+      expect {
+        post :create, format: :json, params: { project_id: @project.id, task: new_task }
+      }.to change(@project.tasks, :count).by(1)
+    end
+
+    # 認証を要求すること
+    it 'requres authentication' do
+      new_task = { name: 'New test task' }
+
+      expect {
+        post :create, format: :json, params: { project_id: @project.id, task: new_task }
+      }.to_not change(@project.tasks, :count)
+      expect(response).to_not be_successful
+    end
+  end
+end

--- a/everyday-rspec/spec/factories/projects.rb
+++ b/everyday-rspec/spec/factories/projects.rb
@@ -24,5 +24,10 @@ FactoryBot.define do
     trait :due_tomorrow do
       due_on { 1.day.from_now }
     end
+
+    # 無効になっている
+    trait :invalid do
+      name { nil }
+    end
   end
 end

--- a/everyday-rspec/spec/rails_helper.rb
+++ b/everyday-rspec/spec/rails_helper.rb
@@ -60,4 +60,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  #　コントローラスペックで Deviseのテストヘルパーを使用する
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end


### PR DESCRIPTION
- feat(everyday-rspec/05-controllers): コントローラスペックの基本
- feat(everyday-rspec/05-controllers): コントローラスペックで Deviseのテストヘルパーを使用する
- feat(everyday-rspec/05-controllers): ログイン機能のテスト
- feat(everyday-rspec/05-controllers): 認証が必要なコントローラスペック
- feat(everyday-rspec/05-controllers): ユーザー入力をテストする
- feat(everyday-rspec/05-controllers): ユーザー入力のエラーをテストする
- feat(everyday-rspec/05-controllers): hTML以外の出力を扱う
