### PR TITLE
everyday rspec/08 dry specs

### DIFF
--- a/everyday-rspec/README.md
+++ b/everyday-rspec/README.md
@@ -1,2 +1,5 @@
 # 参考リポジトリ
 https://github.com/JunichiIto/everydayrails-rspec-jp-2022
+
+# テストをきれいにする便利なマッチャーを提供する
+[thoughtbot/shoulda-matchers: Simple one-liner tests for common Rails functionality](https://github.com/thoughtbot/shoulda-matchers)

--- a/everyday-rspec/spec/controllers/projects_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/projects_controller_spec.rb
@@ -12,14 +12,10 @@ RSpec.describe ProjectsController, type: :controller do
       it "responds successfully" do
         sign_in(@user)
         get :index
-        expect(response).to be_successful
-      end
-
-      # 200レスポンスを返すこと
-      it "responds a 200 response" do
-        sign_in(@user)
-        get :index
-        expect(response).to have_http_status "200"
+        aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_http_status "200"
+        end
       end
     end
 

--- a/everyday-rspec/spec/controllers/tasks_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/tasks_controller_spec.rb
@@ -1,17 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
-  before do
-    @user = FactoryBot.create(:user)
-    @project = FactoryBot.create(:project, owner: @user)
-    @task = @project.tasks.create!(name: "Test task")
-  end
+  include_context "project setup"
 
   describe '#show' do
     # JSON形式でレスポンスを返すこと
     it 'responds with JSON formatted output' do
-      sign_in(@user)
-      get :show, format: :json, params: { project_id: @project.id, id: @task.id }
+      sign_in(user)
+      get :show, format: :json, params: { project_id: project.id, id: task.id }
       expect(response.content_type).to include('application/json')
     end
   end
@@ -20,18 +16,18 @@ RSpec.describe TasksController, type: :controller do
     # JSON形式でレスポンスを返すこと
     it 'responds with JSON formatted output' do
       new_task = { name: 'New test task' }
-      sign_in(@user)
-      post :create, format: :json, params: { project_id: @project.id, task: new_task }
+      sign_in(user)
+      post :create, format: :json, params: { project_id: project.id, task: new_task }
       expect(response.content_type).to include('application/json')
     end
 
     # 新しいタスクをプロジェクトに追加すること
     it 'adds a new task to the project' do
       new_task = { name: 'New test task' }
-      sign_in(@user)
+      sign_in(user)
       expect {
-        post :create, format: :json, params: { project_id: @project.id, task: new_task }
-      }.to change(@project.tasks, :count).by(1)
+        post :create, format: :json, params: { project_id: project.id, task: new_task }
+      }.to change(project.tasks, :count).by(1)
     end
 
     # 認証を要求すること
@@ -39,8 +35,8 @@ RSpec.describe TasksController, type: :controller do
       new_task = { name: 'New test task' }
 
       expect {
-        post :create, format: :json, params: { project_id: @project.id, task: new_task }
-      }.to_not change(@project.tasks, :count)
+        post :create, format: :json, params: { project_id: project.id, task: new_task }
+      }.to_not change(project.tasks, :count)
       expect(response).to_not be_successful
     end
   end

--- a/everyday-rspec/spec/controllers/tasks_controller_spec.rb
+++ b/everyday-rspec/spec/controllers/tasks_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TasksController, type: :controller do
     it 'responds with JSON formatted output' do
       sign_in(user)
       get :show, format: :json, params: { project_id: project.id, id: task.id }
-      expect(response.content_type).to include('application/json')
+      expect(response).to have_content_type :json
     end
   end
 
@@ -18,7 +18,7 @@ RSpec.describe TasksController, type: :controller do
       new_task = { name: 'New test task' }
       sign_in(user)
       post :create, format: :json, params: { project_id: project.id, task: new_task }
-      expect(response.content_type).to include('application/json')
+      expect(response).to be_content_type :json # カスタムマッチャーのエイリアス
     end
 
     # 新しいタスクをプロジェクトに追加すること

--- a/everyday-rspec/spec/factories/tasks.rb
+++ b/everyday-rspec/spec/factories/tasks.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :task do
+    
+  end
+end

--- a/everyday-rspec/spec/models/note_spec.rb
+++ b/everyday-rspec/spec/models/note_spec.rb
@@ -1,31 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Note, type: :model do
-  # ファクトリで関連するデータを作成する
-  it "generates assocated data from a factory" do
-    note = FactoryBot.create(:note)
-    puts "This note's project is #{note.project.inspect}"
-    puts "This note's user is #{note.user.inspect}"
-  end
-
-  before do
-    @user = User.create(
-      first_name: 'Jane',
-      last_name: 'Tester',
-      email: 'test@example.com',
-      password: 'dottle-nouveau-pavilion-tights-furze',
-    )
-
-    @project = @user.projects.create(
-      name: "Test Project"
-    )
-  end
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) { FactoryBot.create(:project, owner: user) }
 
   # ユーザー、プロジェクト、メッセージがあれば有効な状態であること
   it "is valid with a user, projct, message" do
     note = Note.new(
-      user: @user,
-      project: @project,
+      user: user,
+      project: project,
       message: "This is a simple note.",
     )
 
@@ -34,39 +17,43 @@ RSpec.describe Note, type: :model do
 
   # メッセージがなければ無効なこと
   it "is invalid withiout a message." do
-    note = Note.new(
-      user: @user,
-      project: @project,
-    )
-
+    note = Note.new(message: nil)
     note.valid?
     expect(note.errors[:message]).to include("can't be blank")
   end
 
   # 検索文字列に一致するメッセージを検索する
   describe "search message for a term" do
-    before do
-      @note1 = @project.notes.create(
-        message: "This is the first note.",
-        user: @user,
+    let!(:note1) {
+      FactoryBot.create(:note,
+        project: project,
+        user: user,
+        message: "This is the first note."
       )
+    }
 
-      @note2 = @project.notes.create(
-        message: "This is the second note.",
-        user: @user,
-      )
 
-      @note3 = @project.notes.create(
-        message: "First, preheat the oven.",
-        user: @user,
+    let!(:note2) {
+      FactoryBot.create(:note,
+        project: project,
+        user: user,
+        message: "This is the second note."
       )
-    end
+    }
+
+    let!(:note3) {
+      FactoryBot.create(:note,
+        project: project,
+        user: user,
+        message: "First, preheat the oven."
+      )
+    }
 
     # 一致するデータが見つかるとき
     context "when a match is found." do
       # 検索文字列に一致する Note を返すこと
       it "returns notes that match the search term" do
-        expect(Note.search("first")).to include(@note1, @note3)
+        expect(Note.search("first")).to include(note1, note3)
       end
     end
 
@@ -75,6 +62,7 @@ RSpec.describe Note, type: :model do
       # 空のコレクションを返すこと
       it "return an empty collection" do
         expect(Note.search("message")).to be_empty
+        expect(Note.count).to eq 3
       end
     end
   end

--- a/everyday-rspec/spec/models/task_spec.rb
+++ b/everyday-rspec/spec/models/task_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  let(:project) { FactoryBot.create(:project) }
+
+  # プロジェクトと名前があれば有効なこと
+  it "is valid with a project and name" do
+    task = Task.new(
+      project: project,
+      name: "Test task",
+    )
+    expect(task).to be_valid
+  end
+
+  # プロジェクトがなければ無効なこと
+  it "is invalid without a name" do
+    task = Task.new(name: nil)
+    task.valid?
+    expect(task.errors[:name]).to include("can't be blank")
+  end
+end

--- a/everyday-rspec/spec/rails_helper.rb
+++ b/everyday-rspec/spec/rails_helper.rb
@@ -67,4 +67,5 @@ RSpec.configure do |config|
   # Deviseのヘルパーメソッドをテスト内で使用する
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include RequestSpecHelper, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/everyday-rspec/spec/support/contexts/project_setup.rb
+++ b/everyday-rspec/spec/support/contexts/project_setup.rb
@@ -1,0 +1,5 @@
+RSpec.shared_context "project setup" do
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) { FactoryBot.create(:project, owner: user) }
+  let(:task) { project.tasks.create!(name: "Test task") }
+end

--- a/everyday-rspec/spec/support/login_support.rb
+++ b/everyday-rspec/spec/support/login_support.rb
@@ -1,0 +1,13 @@
+module LoginSupport
+  def sign_in_as(user)
+    visit root_path
+    click_link "Sign in"
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_button "Log in"
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/everyday-rspec/spec/support/matchers/content_type.rb
+++ b/everyday-rspec/spec/support/matchers/content_type.rb
@@ -1,0 +1,32 @@
+RSpec::Matchers.define :have_content_type do |expected|
+  match do |actual|
+    begin
+      actual.content_type.include? content_type(expected)
+    rescue ArgumentError
+      false
+    end
+  end
+
+  failure_message do |actual|
+    "Expected \"#{content_type(actual.content_type)} " +
+    "(#{actual.content_type})\" to be Content Type " +
+    "\"#{content_type(expected)}\" (#{expected})"
+  end
+
+  failure_message_when_negated do |actual|
+    "Expected \"#{content_type(actual.content_type)} " +
+    "(#{actual.content_type})\" to not be Content Type " +
+    "\"#{content_type(expected)}\" (#{expected})"
+  end
+
+  def content_type(type)
+    types = {
+      html: "text/html",
+      json: "application/json",
+    }
+    types[type.to_sym] || "unknown content type"
+  end
+end
+
+RSpec::Matchers.alias_matcher :be_content_type, :have_content_type
+# shoulda-matchers gem

--- a/everyday-rspec/spec/system/projects_spec.rb
+++ b/everyday-rspec/spec/system/projects_spec.rb
@@ -4,12 +4,7 @@ RSpec.describe "Projects", type: :system do
   # ユーザーは新しいプロジェクトを作成する
   it 'creates a new project as a user' do
     user = FactoryBot.create(:user)
-
-    visit root_path
-    click_link 'Sign in'
-    fill_in 'Email', with: user.email
-    fill_in 'Password', with: user.password
-    click_button 'Log in'
+    sign_in_as user
 
     expect {
       click_link 'New Project'

--- a/everyday-rspec/spec/system/projects_spec.rb
+++ b/everyday-rspec/spec/system/projects_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Projects", type: :system do
   it 'creates a new project as a user' do
     user = FactoryBot.create(:user)
     sign_in user
-
     visit root_path
 
     expect {
@@ -13,10 +12,12 @@ RSpec.describe "Projects", type: :system do
       fill_in 'Name', with: 'Test Project'
       fill_in 'Description', with: 'Trying out Capybara'
       click_button 'Create Project'
+    }.to change(user.projects, :count).by(1)
 
+    aggregate_failures do
       expect(page).to have_content 'Project was successfully created'
       expect(page).to have_content 'Test Project'
       expect(page).to have_content "Owner: #{user.name}"
-    }.to change(user.projects, :count).by(1)
+    end
   end
 end

--- a/everyday-rspec/spec/system/projects_spec.rb
+++ b/everyday-rspec/spec/system/projects_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe "Projects", type: :system do
   # ユーザーは新しいプロジェクトを作成する
   it 'creates a new project as a user' do
     user = FactoryBot.create(:user)
-    sign_in_as user
+    sign_in user
+
+    visit root_path
 
     expect {
       click_link 'New Project'

--- a/everyday-rspec/spec/system/tasks_spec.rb
+++ b/everyday-rspec/spec/system/tasks_spec.rb
@@ -1,30 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :system do
-  # ユーザーがタスクの状態を切り替える
-  scenario "user toggles a task", js: true do
-    user = FactoryBot.create(:user)
-    project = FactoryBot.create(:project,
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) {
+    FactoryBot.create(:project,
       name: "RSpec tutorial",
       owner: user
     )
-    task = project.tasks.create!(name: "Finish RSpec tutorial")
+  }
+  let!(:task) { project.tasks.create!(name: "Finish RSpec tutorial") }
 
+  # ユーザーがタスクの状態を切り替える
+  scenario "user toggles a task", js: true do
+    sign_in user
+    go_to_project "RSpec tutorial"
+
+    complete_task "Finish RSpec tutorial"
+    expect_complete_task "Finish RSpec tutorial"
+
+    undo_complete_task "Finish RSpec tutorial"
+    expect_incomplete_task "Finish RSpec tutorial"
+  end
+
+  def go_to_project(name)
     visit root_path
-    click_link "Sign in"
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Log in"
+    click_link name
+  end
 
-    click_link "RSpec tutorial"
-    check "Finish RSpec tutorial"
+  def complete_task(name)
+    check name
+  end
 
-    expect(page).to have_css "label#task_#{task.id}.completed"
-    expect(task.reload).to be_completed
+  def undo_complete_task(name)
+    uncheck name
+  end
 
-    uncheck "Finish RSpec tutorial"
+  def expect_complete_task(name)
+    aggregate_failures do
+      expect(page).to have_css "label.completed", text: name
+      expect(task.reload).to be_completed
+    end
+  end
 
-    expect(page).to_not have_css "label#task_#{task.id}.completed"
-    expect(task.reload).to_not be_completed
+  def expect_incomplete_task(name)
+    aggregate_failures do
+      expect(page).to_not have_css "label.completed", text: name
+      expect(task.reload).to_not be_completed
+    end
   end
 end


### PR DESCRIPTION
- feat(everyday-rspec/08-dry-specs): テストに共通の処理をモジュールに切り出す
- feat(everyday-rspec/08-dry-specs): 'Deviseのヘルパーメソッドをテスト内で利用する
- feat(everyday-rspec/08-dry-specs): letで遅延読み込みする
- refactor(everyday-rspec/08-dry-specs): shared_context(contextの共有)
- feat(everyday-rspec/08-dry-spec): カスタムマッチャ
- refactor(everyday-rspec/08-dry-specs): aggregate_failures(失敗の集約)
- feat(everyday-rspec/08-dry-specs): テストの可読性を改善する
